### PR TITLE
Add import/order rule

### DIFF
--- a/RULES.md
+++ b/RULES.md
@@ -2446,7 +2446,7 @@ import foo from './foo';
 foo();
 ```
 
-### import/no-named-default (**errorr**)
+### import/no-named-default (**error**)
 
 Reports use of a default export as a locally named import.
 
@@ -2458,4 +2458,26 @@ import { default as foo } from './foo';
 
 // CORRECT
 import foo from './foo';
+```
+
+### import/order' (**error**, *newlines-between*: always)
+
+Enforce a convention in the order of require() / import statements. The --fix option on the command line automatically fixes problems reported by this rule.
+
+More info: [link](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/order.md)
+
+```javascript
+// INCORRECT
+import index from './';
+import fs from 'fs';
+import sibling from './foo';
+import path from 'path';
+
+// CORRECT
+import fs from 'fs';
+import path from 'path';
+
+import index from './';
+
+import sibling from './foo';
 ```

--- a/index.js
+++ b/index.js
@@ -204,6 +204,7 @@ module.exports = {
     'import/extensions': [2, { js: 'never', jsx: 'never', json: 'never' }],
     'import/newline-after-import': 2,
     'import/no-named-default': 2,
+    'import/order': [2, { 'newlines-between': 'always' }],
     'babel/object-curly-spacing': [2, 'always'],
     'babel/no-invalid-this': 2,
     'babel/semi': 2,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-brainhub",
-  "version": "1.11.1",
+  "version": "1.12.0",
   "description": "ESLint shareable config for the Brainhub style",
   "license": "Apache-2.0",
   "repository": "adam-golab/eslint-config-brainhub",

--- a/test/test.js
+++ b/test/test.js
@@ -1,7 +1,9 @@
 'use strict';
 
 const assert = require('assert');
+
 const eslint = require('eslint');
+
 const conf = require('../');
 
 // The source files to lint.


### PR DESCRIPTION
Adding a rule that sorts imports by groups and by convention:

- built-in modules
- new line
- external modules
- new line
- parent modules
- new line
- sibling modules
- new line
- index modules

More info in RULES.md.

This rule will reorder all imports, not sure which version I should bump. Probably `major`. Suggestions?

